### PR TITLE
Less GC triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.10] 2024-07-16
+### Added
+- Implemented patches to reduce memory allocation:
+	- `AudioReverbTrigger` no longer allocates every frame by avoiding the retrieval of a collider tag.
+	- `HangarShipDoor` no longer allocates every frame by replacing `string.Format` with `TMP_Text.SetText(string, float)`.
+	- `WaveFileWriter` no longer allocates by rewriting Mono `BinaryWriter.Write(float)` to avoid array allocation with every write.
+	- Resolved an issue where the local username billboard was toggling between enabled and disabled every frame, leading to unnecessary memory allocation.
+### Fixed
+- Resolved an exception thrown by another mod attempting to access the object instance while in the main menu.
+
 ## [0.0.9] 2024-07-08
 ### Added
 - Further optimized the process of finding a singleton object by not sorting by instance id.

--- a/LethalPerformance/API/ObjectExtensions.TagSystem.cs
+++ b/LethalPerformance/API/ObjectExtensions.TagSystem.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine;
+
+namespace LethalPerformance.API;
+internal static partial class ObjectExtensions
+{
+    public static bool ComparePlayerRagdollTag(GameObject gameObject)
+    {
+        return gameObject.CompareTag("PlayerRagdoll")
+            || gameObject.CompareTag("PlayerRagdoll1")
+            || gameObject.CompareTag("PlayerRagdoll2")
+            || gameObject.CompareTag("PlayerRagdoll3");
+    }
+}

--- a/LethalPerformance/API/ObjectExtensions.cs
+++ b/LethalPerformance/API/ObjectExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
 
 namespace LethalPerformance.API;
-internal static class ObjectExtensions
+internal static partial class ObjectExtensions
 {
     public static T? FindObjectByTypeNonOrdered<T>() where T : Object
     {

--- a/LethalPerformance/CSyncFixer.cs
+++ b/LethalPerformance/CSyncFixer.cs
@@ -1,0 +1,67 @@
+﻿#if ENABLE_PROFILER
+using System;
+using System.Reflection;
+using HarmonyLib;
+using LethalPerformance.API;
+using Unity.Netcode;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace LethalPerformance;
+internal static class CSyncFixer
+{
+    private static PropertyInfo? s_CSyncPrefab;
+    private static PropertyInfo? s_ConfigInstanceKey;
+    private static bool s_CSyncPatched;
+
+    [InitializeOnAwake]
+    public static void Initialize()
+    {
+        // fixes csync doesn't work well without a mod FixPluginTypesSerialization
+        SceneManager.sceneLoaded += SceneManager_sceneLoaded;
+    }
+
+    private static void SceneManager_sceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
+    {
+        if (s_CSyncPatched || scene.name != "MainMenu")
+        {
+            return;
+        }
+
+        var configSyncBehaviourType = Type.GetType("CSync.Lib.ConfigSyncBehaviour,com.sigurd.csync");
+        if (configSyncBehaviourType == null)
+        {
+            LethalPerformancePlugin.Instance.Logger.LogInfo("Failed to find CSync mod");
+            return;
+        }
+
+        s_ConfigInstanceKey = configSyncBehaviourType
+            .GetProperty("ConfigInstanceKey", AccessTools.all);
+
+        s_CSyncPrefab = configSyncBehaviourType.Assembly
+            .GetType("CSync.Lib.ConfigManager")
+            .GetProperty("Prefab", AccessTools.all);
+
+        var methodToPatch = configSyncBehaviourType
+            .GetMethod("Awake", AccessTools.all);
+
+        LethalPerformancePlugin.Instance.Harmony?.CreateProcessor(methodToPatch)
+            .AddPrefix(SymbolExtensions.GetMethodInfo((NetworkBehaviour x) => FixSerializedKey(x)))
+            .Patch();
+
+        s_CSyncPatched = true;
+    }
+
+    public static void FixSerializedKey(NetworkBehaviour __instance)
+    {
+        var components = __instance.gameObject.GetComponents<Object>();
+
+        var selfComponentIndex = Array.IndexOf(components, __instance);
+
+        var prefabComponents = ((GameObject)s_CSyncPrefab!.GetValue(null)).GetComponents<Object>();
+
+        var value = s_ConfigInstanceKey!.GetValue(prefabComponents[selfComponentIndex]);
+        s_ConfigInstanceKey.SetValue(__instance, value);
+    }
+}
+#endif

--- a/LethalPerformance/Extensions/BinaryPrimitivesExtension.cs
+++ b/LethalPerformance/Extensions/BinaryPrimitivesExtension.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+
+namespace LethalPerformance.Extensions;
+internal static class BinaryPrimitivesExtension
+{
+    // In .netstandard2.1 BinaryPrimitives.WriteSingleLittleEndian doesn't exists, using code from dotnet runtime
+    public static void WriteSingleLittleEndian(Span<byte> destination, float value)
+    {
+        if (BitConverter.IsLittleEndian)
+        {
+            MemoryMarshal.Write(destination, ref value);
+        }
+        else
+        {
+            var temp = BinaryPrimitives.ReverseEndianness(BitConverter.SingleToInt32Bits(value));
+
+            MemoryMarshal.Write(destination, ref temp);
+        }
+    }
+}

--- a/LethalPerformance/LethalPerformance.csproj
+++ b/LethalPerformance/LethalPerformance.csproj
@@ -33,6 +33,12 @@
       <IncludeOriginalAttributesAttribute>false</IncludeOriginalAttributesAttribute>
       <Strip>false</Strip>
     </Publicize>
+    <Publicize Include="DissonanceVoip">
+      <PublicizeTarget>all</PublicizeTarget>
+      <PublicizeCompilerGenerated>false</PublicizeCompilerGenerated>
+      <IncludeOriginalAttributesAttribute>false</IncludeOriginalAttributesAttribute>
+      <Strip>false</Strip>
+    </Publicize>
   </ItemGroup>
 
   <ItemGroup>

--- a/LethalPerformance/LethalPerformancePlugin.cs
+++ b/LethalPerformance/LethalPerformancePlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using BepInEx;
@@ -40,7 +41,11 @@ public class LethalPerformancePlugin : BaseUnityPlugin
 
         LoadGameBurstLib();
         CallInitializeOnAwake();
+        InitializeHarmony();
+    }
 
+    private void InitializeHarmony()
+    {
         // disables bepinex harmony logger filter temporarily
         var oldFilter = HarmonyLib.Tools.Logger.ChannelFilter;
         if ((oldFilter & HarmonyLib.Tools.Logger.LogChannel.IL) == 0)
@@ -50,7 +55,14 @@ public class LethalPerformancePlugin : BaseUnityPlugin
         }
 
         m_Harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);
-        m_Harmony.PatchAll(typeof(LethalPerformancePlugin).Assembly);
+        try
+        {
+            m_Harmony.PatchAll(typeof(LethalPerformancePlugin).Assembly);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex);
+        }
 
         HarmonyLib.Tools.Logger.ChannelFilter = oldFilter;
     }

--- a/LethalPerformance/LethalPerformancePlugin.cs
+++ b/LethalPerformance/LethalPerformancePlugin.cs
@@ -21,8 +21,7 @@ public class LethalPerformancePlugin : BaseUnityPlugin
     internal new ManualLogSource Logger { get; private set; } = null!;
     internal string WorkingDirectory { get; private set; } = null!;
     internal new ConfigManager Config { get; private set; } = null!;
-
-    private Harmony? m_Harmony;
+    internal Harmony? Harmony { get; private set; }
 
     private void Awake()
     {
@@ -54,10 +53,10 @@ public class LethalPerformancePlugin : BaseUnityPlugin
             HarmonyLib.Tools.Logger.ChannelFilter = HarmonyLib.Tools.Logger.LogChannel.None;
         }
 
-        m_Harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);
+        Harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);
         try
         {
-            m_Harmony.PatchAll(typeof(LethalPerformancePlugin).Assembly);
+            Harmony.PatchAll(typeof(LethalPerformancePlugin).Assembly);
         }
         catch (Exception ex)
         {
@@ -91,6 +90,17 @@ public class LethalPerformancePlugin : BaseUnityPlugin
         if (!File.Exists(burstLibPath))
         {
             Logger.LogFatal($"Failed to find \"{c_LibName}\"");
+            return;
+        }
+
+        try
+        {
+            var fileStream = new FileStream(burstLibPath, FileMode.Create, FileAccess.Read, FileShare.None);
+            fileStream.Dispose();
+        }
+        catch
+        {
+            Logger.LogFatal("Failed to open burst library. Probably file is locked by other process or antivirus is blocking the access");
             return;
         }
 

--- a/LethalPerformance/LethalPerformancePlugin.cs
+++ b/LethalPerformance/LethalPerformancePlugin.cs
@@ -95,7 +95,7 @@ public class LethalPerformancePlugin : BaseUnityPlugin
 
         try
         {
-            var fileStream = new FileStream(burstLibPath, FileMode.Create, FileAccess.Read, FileShare.None);
+            var fileStream = new FileStream(burstLibPath, FileMode.Open, FileAccess.Read, FileShare.None);
             fileStream.Dispose();
         }
         catch

--- a/LethalPerformance/Patches/FindingObjectOptimization/NativeFindObjectOfTypePatch.cs
+++ b/LethalPerformance/Patches/FindingObjectOptimization/NativeFindObjectOfTypePatch.cs
@@ -37,7 +37,7 @@ internal static class NativeFindObjectOfTypePatch
         {
             __result = getter();
 
-            if (__result.m_CachedPtr != IntPtr.Zero)
+            if (__result != null)
             {
                 return false;
             }

--- a/LethalPerformance/Patches/Patch_AudioReverbTrigger.cs
+++ b/LethalPerformance/Patches/Patch_AudioReverbTrigger.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+using LethalPerformance.API;
+using UnityEngine;
+
+namespace LethalPerformance.Patches;
+[HarmonyPatch(typeof(AudioReverbTrigger), nameof(AudioReverbTrigger.OnTriggerStay))]
+internal static class Patch_AudioReverbTrigger
+{
+    [HarmonyCleanup]
+    public static Exception? Cleanup(Exception exception)
+    {
+        return HarmonyExceptionHandler.ReportException(exception);
+    }
+
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> FixTagAllocation(IEnumerable<CodeInstruction> instructions)
+    {
+        var matcher = new CodeMatcher(instructions);
+
+        var gameObjectTagGetter = typeof(GameObject).GetProperty(nameof(GameObject.tag), AccessTools.all).GetMethod;
+
+        matcher.MatchForward(false,
+            new(OpCodes.Callvirt, gameObjectTagGetter),
+            new(OpCodes.Ldstr),
+            new(OpCodes.Callvirt))
+            .RemoveInstructions(3)
+            .Insert(CodeInstruction.Call((GameObject x) => ObjectExtensions.ComparePlayerRagdollTag(x)));
+
+        return matcher.InstructionEnumeration();
+    }
+}

--- a/LethalPerformance/Patches/Patch_HangarShipDoor.cs
+++ b/LethalPerformance/Patches/Patch_HangarShipDoor.cs
@@ -1,12 +1,20 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection.Emit;
 using HarmonyLib;
+using LethalPerformance.API;
 using TMPro;
 
 namespace LethalPerformance.Patches;
 [HarmonyPatch(typeof(HangarShipDoor))]
 internal static class Patch_HangarShipDoor
 {
+    [HarmonyCleanup]
+    public static Exception? Cleanup(Exception exception)
+    {
+        return HarmonyExceptionHandler.ReportException(exception);
+    }
+
     [HarmonyPatch(nameof(HangarShipDoor.Update))]
     [HarmonyTranspiler]
     public static IEnumerable<CodeInstruction> FixFormatAllocation(IEnumerable<CodeInstruction> instructions)

--- a/LethalPerformance/Patches/Patch_HangarShipDoor.cs
+++ b/LethalPerformance/Patches/Patch_HangarShipDoor.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+using TMPro;
+
+namespace LethalPerformance.Patches;
+[HarmonyPatch(typeof(HangarShipDoor))]
+internal static class Patch_HangarShipDoor
+{
+    [HarmonyPatch(nameof(HangarShipDoor.Update))]
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> FixFormatAllocation(IEnumerable<CodeInstruction> instructions)
+    {
+        var matcher = new CodeMatcher(instructions);
+
+        // todo: add check if text should be updated?
+
+        matcher.MatchForward(false,
+            new(OpCodes.Box),
+            new(OpCodes.Call),
+            new(OpCodes.Callvirt))
+            .SetInstructionAndAdvance(new CodeInstruction(OpCodes.Conv_R4)) // convert int to float
+            .RemoveInstruction() // remove string.Format call
+            .Set(OpCodes.Call, typeof(TMP_Text).GetMethod(nameof(TMP_Text.SetText), [typeof(string), typeof(float)]));
+
+        return matcher.InstructionEnumeration();
+    }
+}

--- a/LethalPerformance/Patches/Patch_PlayerControllerB.cs
+++ b/LethalPerformance/Patches/Patch_PlayerControllerB.cs
@@ -1,0 +1,21 @@
+﻿using GameNetcodeStuff;
+using HarmonyLib;
+
+namespace LethalPerformance.Patches;
+[HarmonyPatch(typeof(PlayerControllerB))]
+internal static class Patch_PlayerControllerB
+{
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(PlayerControllerB.ShowNameBillboard))]
+    public static bool FixLocalBillBoardIsEnabling(PlayerControllerB __instance, bool __runOriginal)
+    {
+        // todo: remove CanvasScaler and GraphicRaycaster from billboard
+        if (!__runOriginal)
+        {
+            return __runOriginal;
+        }
+
+        var isLocalPlayer = __instance == StartOfRound.Instance.localPlayerController;
+        return !isLocalPlayer;
+    }
+}

--- a/LethalPerformance/Patches/Patch_PlayerControllerB.cs
+++ b/LethalPerformance/Patches/Patch_PlayerControllerB.cs
@@ -1,10 +1,18 @@
-﻿using GameNetcodeStuff;
+﻿using System;
+using GameNetcodeStuff;
 using HarmonyLib;
+using LethalPerformance.API;
 
 namespace LethalPerformance.Patches;
 [HarmonyPatch(typeof(PlayerControllerB))]
 internal static class Patch_PlayerControllerB
 {
+    [HarmonyCleanup]
+    public static Exception? Cleanup(Exception exception)
+    {
+        return HarmonyExceptionHandler.ReportException(exception);
+    }
+
     [HarmonyPrefix]
     [HarmonyPatch(nameof(PlayerControllerB.ShowNameBillboard))]
     public static bool FixLocalBillBoardIsEnabling(PlayerControllerB __instance, bool __runOriginal)

--- a/LethalPerformance/Patches/Patch_WaveFileWriter.cs
+++ b/LethalPerformance/Patches/Patch_WaveFileWriter.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using LethalPerformance.Extensions;
+using NAudio.Wave;
+
+namespace LethalPerformance.Patches;
+[HarmonyPatch]
+internal static class Patch_WaveFileWriter
+{
+    private static readonly byte[] s_RIFF = "RIFF"u8.ToArray();
+    private static readonly byte[] s_WAVE = "WAVE"u8.ToArray();
+    private static readonly byte[] s_Fmt = "fmt "u8.ToArray();
+    private static readonly byte[] s_Data = "data"u8.ToArray();
+    private static readonly byte[] s_Fact = "fact"u8.ToArray();
+
+    private static readonly Dictionary<string, FieldInfo> s_StringToFieldMapping = new()
+    {
+        ["RIFF"] = typeof(Patch_WaveFileWriter).GetField(nameof(s_RIFF), AccessTools.all),
+        ["WAVE"] = typeof(Patch_WaveFileWriter).GetField(nameof(s_WAVE), AccessTools.all),
+        ["fmt "] = typeof(Patch_WaveFileWriter).GetField(nameof(s_Fmt), AccessTools.all),
+        ["data"] = typeof(Patch_WaveFileWriter).GetField(nameof(s_Data), AccessTools.all),
+        ["fact"] = typeof(Patch_WaveFileWriter).GetField(nameof(s_Fact), AccessTools.all),
+    };
+
+    [HarmonyPatch(typeof(WaveFileWriter), MethodType.Constructor, typeof(Stream), typeof(WaveFormat))]
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> FixConstructorAllocations(IEnumerable<CodeInstruction> instructions)
+    {
+        return ReplaceASCIICallToStaticField(instructions);
+    }
+
+    [HarmonyPatch(typeof(WaveFileWriter), nameof(WaveFileWriter.WriteDataChunkHeader))]
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> FixWriteDataChunkHeaderAllocations(IEnumerable<CodeInstruction> instructions)
+    {
+        return ReplaceASCIICallToStaticField(instructions);
+    }
+
+    [HarmonyPatch(typeof(WaveFileWriter), nameof(WaveFileWriter.CreateFactChunk))]
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> FixCreateFactChunkAllocations(IEnumerable<CodeInstruction> instructions)
+    {
+        return ReplaceASCIICallToStaticField(instructions);
+    }
+
+    private static IEnumerable<CodeInstruction> ReplaceASCIICallToStaticField(IEnumerable<CodeInstruction> instructions)
+    {
+        var matcher = new CodeMatcher(instructions);
+
+        matcher.MatchForward(false, [new(OpCodes.Call), new(OpCodes.Ldstr), new(OpCodes.Callvirt)])
+            .Repeat(m =>
+            {
+                var loadStringValue = (string)m.InstructionAt(1).operand;
+                var byteArray = s_StringToFieldMapping[loadStringValue];
+
+                m.RemoveInstructions(3)
+                .Insert(new CodeInstruction(OpCodes.Ldsfld, byteArray));
+            });
+
+        return matcher.InstructionEnumeration();
+    }
+
+    [HarmonyPatch(typeof(WaveFileWriter), nameof(WaveFileWriter.WriteSample))]
+    [HarmonyTranspiler]
+    private static IEnumerable<CodeInstruction> FixWriterFloatAllocation(IEnumerable<CodeInstruction> _)
+    {
+        return
+        [
+            new(OpCodes.Ldarg_0),
+            new(OpCodes.Ldarg_1),
+            CodeInstruction.Call((WaveFileWriter x, float y) => WriteSample(x, y)),
+            new(OpCodes.Ret)
+        ];
+    }
+
+    private static void WriteSample(WaveFileWriter waveFileWriter, float sample)
+    {
+        // Mono BinaryWriter.Write(float) allocates array, using our write method
+
+        Span<byte> buffer = stackalloc byte[sizeof(float)];
+        BinaryPrimitivesExtension.WriteSingleLittleEndian(buffer, sample);
+
+        waveFileWriter._outStream.Write(buffer);
+        waveFileWriter._dataSizePos += 4;
+    }
+}

--- a/LethalPerformance/Patches/Patch_WaveFileWriter.cs
+++ b/LethalPerformance/Patches/Patch_WaveFileWriter.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
+using LethalPerformance.API;
 using LethalPerformance.Extensions;
 using NAudio.Wave;
 
@@ -25,6 +26,12 @@ internal static class Patch_WaveFileWriter
         ["data"] = typeof(Patch_WaveFileWriter).GetField(nameof(s_Data), AccessTools.all),
         ["fact"] = typeof(Patch_WaveFileWriter).GetField(nameof(s_Fact), AccessTools.all),
     };
+
+    [HarmonyCleanup]
+    public static Exception? Cleanup(Exception exception)
+    {
+        return HarmonyExceptionHandler.ReportException(exception);
+    }
 
     [HarmonyPatch(typeof(WaveFileWriter), MethodType.Constructor, typeof(Stream), typeof(WaveFormat))]
     [HarmonyTranspiler]
@@ -68,6 +75,7 @@ internal static class Patch_WaveFileWriter
     [HarmonyTranspiler]
     private static IEnumerable<CodeInstruction> FixWriterFloatAllocation(IEnumerable<CodeInstruction> _)
     {
+        // if some mod are also patching this, lmk to add compatibility
         return
         [
             new(OpCodes.Ldarg_0),


### PR DESCRIPTION
- `AudioReverbTrigger` no longer allocates every frame by avoiding the retrieval of a collider tag.
- `HangarShipDoor` no longer allocates every frame by replacing `string.Format` with `TMP_Text.SetText(string, float)`.
- `WaveFileWriter` no longer allocates by rewriting Mono `BinaryWriter.Write(float)` to avoid array allocation with every write.
- Fixed issue where the local username billboard was being enabled and disabled every frame.

Miscellaneous changes:
- Added support for CSync in the development build.